### PR TITLE
Remove unused aws_profile input variable from AWS module

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -23,7 +23,6 @@ module "cdp_aws_quickstart" {
   env_prefix = var.env_prefix
   aws_region = var.aws_region
 
-  aws_profile  = var.aws_profile
   aws_key_pair = var.aws_key_pair
 
   deployment_template = var.deployment_template


### PR DESCRIPTION
Requires https://github.com/cloudera-labs/terraform-cdp-modules/pull/7