### PR TITLE
Updates for authentication options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ export ARM_TENANT_ID="<sp_tenant_id>"
 export ARM_SUBSCRIPTION_ID="<sp_subscription_id>" 
 ```
 
+* The Azure API permissions listed are required by the provisioning account to create the Azure pre-requisite resources.
+
+| API Permission    | Purpose |
+| ------------------| ------- |
+| Microsoft Graph - Application.ReadWrite.All   | Read and write all applications |
+| Microsoft Graph - Application.ReadWrite.OwnedBy | Manage apps that this app creates or owns |
+| Microsoft Graph - AppRoleAssignment.ReadWrite.All | Manage app permission grants and app role assignments |
+| Microsoft Graph - Directory.ReadWrite.All | Read and write directory data |
+| Microsoft Graph - User.Read | Sign in and read user profile |
+
 ### Input file configuration
 
 The `terraform.tfvars.template` file in the required cloud provider directory contains the user-facing configuration. Edit this file to match your particular deployment.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ To use the module provided here, you will need the following prerequisites:
 
 * Terraform can be installed by following the instructions at https://developer.hashicorp.com/terraform/downloads
 
+#### Notes on AWS authentication
+
+* Details of the different methods to authenticate with AWS are available in the [aws Terraform provider docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration).
+
+* The most common ways to specify AWS access and secret keys are:
+  * via environment variables (i.e. setting the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) or;
+  * via shared configuration/credential files (e.g. the `$HOME/.aws/credentials` file). The `AWS_PROFILE` environment variable can be set to specify a named AWS profile. 
+
+* Note that the AWS region to use should always be specifed as a Terraform input variable (with the `aws_region` variable). This region variable is also used an input to the CDP deploy module used to identify the Cloud Provider region.
+
 #### Notes on Azure authentication
 
 * Where you have more than one Azure Subscription the id to use can be passed via the the `ARM_SUBSCRIPTION_ID` environment variable.

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 provider "aws" {
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 module "cdp_aws_prereqs" {

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 provider "aws" {
-  profile = var.aws_profile
   region  = var.aws_region
 }
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # ------- Global settings -------
-variable "aws_profile" {
-  type        = string
-  description = "Profile for AWS cloud credentials"
-
-  # Profile is default unless explicitly specified
-  default = "default"
-}
-
 variable "aws_region" {
   type        = string
   description = "Region which Cloud resources will be created"


### PR DESCRIPTION
For AWS:
* Removed requirement for aws_profile input variable to allow auth via environment variables;
* Added notes about the different ways to authenticate

For Azure:
* Added the required Azure API permissions for the provisioning account/service principal