### PR TITLE
Reduce number of mandatory inputs in quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,10 @@ env_prefix = "<ENTER_VALUE>" # Required name prefix for cloud and CDP resources,
 
 # ------- Cloud Settings -------
 aws_region = "<ENTER_VALUE>" # Change this to specify Cloud Provider region, e.g. eu-west-1
-aws_key_pair = "<ENTER_VALUE>" # Change this with the name of a pre-existing AWS keypair, e.g. my-keypair
 
 # ------- CDP Environment Deployment -------
 deployment_template = "<ENTER_VALUE>"  # Specify the deployment pattern below. Options are public, semi-private or private
 
-# ------- Network Settings -------
-# **NOTE: If required change the values below any additional CIDRs to add the the AWS Security Groups**
-ingress_extra_cidrs_and_ports = {
- cidrs = ["<ENTER_IP_VALUE>/32", "<ENTER_IP_VALUE>/32"],
- ports = [443, 22]
-}
 ```
 
 #### Sample Configuration file for Azure
@@ -114,19 +107,10 @@ ingress_extra_cidrs_and_ports = {
 env_prefix = "<ENTER_VALUE>" # Required name prefix for cloud and CDP resources, e.g. cldr1
 
 # ------- Cloud Settings -------
-azure_region = "<ENTER_VALUE>" # Change this to specify Cloud Provider region, e.g. westeurpoe
-
-public_key_text = "<ENTER_VALUE>" # Change this with the SSH public key text, e.g. ssh-rsa AAA....
+azure_region = "<ENTER_VALUE>" # Change this to specify Cloud Provider region, e.g. eastus
 
 # ------- CDP Environment Deployment -------
 deployment_template = "<ENTER_VALUE>"  # Specify the deployment pattern below. Options are public, semi-private or private
-
-# ------- Network Settings -------
-# **NOTE: If required change the values below any additional CIDRs to add the the AWS Security Groups**
-ingress_extra_cidrs_and_ports = {
- cidrs = ["<ENTER_IP_VALUE>/32", "<ENTER_IP_VALUE>/32"],
- ports = [443, 22]
-}
 ```
 
 #### Sample Configuration file for GCP
@@ -140,18 +124,21 @@ gcp_project = "<ENTER_VALUE>" # Change this to specify the GCP Project ID
 
 gcp_region = "<ENTER_VALUE>" # Change this to specify Cloud Provider region, e.g. europe-west2
 
-public_key_text = "<ENTER_VALUE>" # Change this with the SSH public key text, e.g. ssh-rsa AAA....
-
 # ------- CDP Environment Deployment -------
 deployment_template = "<ENTER_VALUE>"  # Specify the deployment pattern below. Options are public, semi-private or private
-
-# ------- Network Settings -------
-# **NOTE: If required change the values below any additional CIDRs to add the the AWS Security Groups**
-ingress_extra_cidrs_and_ports = {
- cidrs = ["<ENTER_IP_VALUE>/32", "<ENTER_IP_VALUE>/32"],
- ports = [443, 22]
-}
 ```
+
+#### SSH keys
+
+By default the Terraform quickstarts will create a new SSH keypair that will be associated with all nodes provisioned by CDP. The private key will be stored in the `<env_prefix>-ssh-key.pem` file of the Terraform cloud provider project directory.
+
+To use an existing SSH key, set the keypair name (for AWS) or public key text (for Azure and GCP) variable in the `terraform.tvars` file.
+
+#### Access to UI and API endpoints
+
+By default inbound access to the UI and API endpoints of your deployment will be allowed from the public IP of executing host. 
+
+To add additional CIDRs or IP ranges, set the optional `ingress_extra_cidrs_and_ports` variable in the `terraform.tvars` file.
 
 ### Create infrastructure
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -93,14 +93,14 @@ locals {
   # key pair value
   aws_key_pair = (
     local.create_keypair == false ?
-    var.aws_key_pair : 
+    var.aws_key_pair :
     aws_key_pair.cdp_keypair[0].key_name
   )
 }
 
 # Create and save a RSA key
 resource "tls_private_key" "cdp_private_key" {
-  count = local.create_keypair ? 1 : 0
+  count     = local.create_keypair ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 4096
 }
@@ -129,19 +129,19 @@ locals {
   lookup_ip = var.ingress_extra_cidrs_and_ports == null ? true : false
 
   # ingress value
-  ingress_extra_cidrs_and_ports = ( 
-    local.lookup_ip == false ? 
-      var.ingress_extra_cidrs_and_ports : 
-      { cidrs = ["${data.http.my_ip[0].response_body}/32"], 
-        ports = [443, 22]
-      }
-    )
+  ingress_extra_cidrs_and_ports = (
+    local.lookup_ip == false ?
+    var.ingress_extra_cidrs_and_ports :
+    { cidrs = ["${data.http.my_ip[0].response_body}/32"],
+      ports = [443, 22]
+    }
+  )
 }
 
 # Perform lookup of public IP of executing host
 data "http" "my_ip" {
   count = local.lookup_ip ? 1 : 0
-  
+
   url = "https://ifconfig.me/ip"
 }
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -23,7 +23,7 @@ module "cdp_aws_prereqs" {
   aws_region = var.aws_region
 
   deployment_template           = var.deployment_template
-  ingress_extra_cidrs_and_ports = var.ingress_extra_cidrs_and_ports
+  ingress_extra_cidrs_and_ports = local.ingress_extra_cidrs_and_ports
 
   # Using CDP TF Provider cred pre-reqs data source for values of xaccount account_id and external_id
   xaccount_account_id  = data.cdp_environments_aws_credential_prerequisites.cdp_prereqs.account_id
@@ -46,7 +46,7 @@ module "cdp_deploy" {
   env_prefix          = var.env_prefix
   infra_type          = "aws"
   region              = var.aws_region
-  keypair_name        = var.aws_key_pair
+  keypair_name        = local.aws_key_pair
   deployment_template = var.deployment_template
 
   # From pre-reqs module output
@@ -83,4 +83,65 @@ terraform {
   }
 }
 data "cdp_environments_aws_credential_prerequisites" "cdp_prereqs" {}
+
+
+# ------- Create SSH Keypair if input aws_key_pair variable is not specified
+locals {
+  # flag to determine if keypair should be created
+  create_keypair = var.aws_key_pair == null ? true : false
+
+  # key pair value
+  aws_key_pair = (
+    local.create_keypair == false ?
+    var.aws_key_pair : 
+    aws_key_pair.cdp_keypair[0].key_name
+  )
+}
+
+# Create and save a RSA key
+resource "tls_private_key" "cdp_private_key" {
+  count = local.create_keypair ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+# Save the private key to ./<env_prefix>-ssh-key.pem
+resource "local_sensitive_file" "pem_file" {
+  count = local.create_keypair ? 1 : 0
+
+  filename             = "${var.env_prefix}-ssh-key.pem"
+  file_permission      = "600"
+  directory_permission = "700"
+  content              = tls_private_key.cdp_private_key[0].private_key_pem
+}
+
+# Create an AWS EC2 keypair from the generated public key
+resource "aws_key_pair" "cdp_keypair" {
+  count = local.create_keypair ? 1 : 0
+
+  key_name   = "${var.env_prefix}-keypair"
+  public_key = tls_private_key.cdp_private_key[0].public_key_openssh
+}
+
+# ------- Lookup public ip for ingress settings if ingress_extra_cidrs_and_ports variable is not specified
+locals {
+  # flag to determine if public ip lookup should be performed for ingress
+  lookup_ip = var.ingress_extra_cidrs_and_ports == null ? true : false
+
+  # ingress value
+  ingress_extra_cidrs_and_ports = ( 
+    local.lookup_ip == false ? 
+      var.ingress_extra_cidrs_and_ports : 
+      { cidrs = ["${data.http.my_ip[0].response_body}/32"], 
+        ports = [443, 22]
+      }
+    )
+}
+
+# Perform lookup of public IP of executing host
+data "http" "my_ip" {
+  count = local.lookup_ip ? 1 : 0
+  
+  url = "https://ifconfig.me/ip"
+}
 

--- a/aws/terraform.tfvars.template
+++ b/aws/terraform.tfvars.template
@@ -17,17 +17,22 @@ env_prefix = "<ENTER_VALUE>" # Required name prefix for cloud and CDP resources,
 
 # ------- Cloud Settings -------
 aws_region = "<ENTER_VALUE>" # Change this to specify Cloud Provider region, e.g. eu-west-1
-aws_key_pair = "<ENTER_VALUE>" # Change this with the name of a pre-existing AWS keypair, e.g. my-keypair
 
 # ------- CDP Environment Deployment -------
 deployment_template = "<ENTER_VALUE>"  # Specify the deployment pattern below. Options are public, semi-private or private
 
-# ------- Network Settings -------
-# **NOTE: If required change the values below any additional CIDRs to add the the AWS Security Groups**
-ingress_extra_cidrs_and_ports = {
- cidrs = ["<ENTER_IP_VALUE>/32", "<ENTER_IP_VALUE>/32"],
- ports = [443, 22]
-}
+
+
+# ------- Optional inputs for SSH key and Network Access Settings -------
+# **NOTE: Uncomment below settings if required
+
+# aws_key_pair = "<ENTER_VALUE>" # Set this to specify the name of a pre-existing AWS keypair, e.g. my-keypair
+
+# If required use the variable below for any additional CIDRs to add the the AWS Security Groups
+# ingress_extra_cidrs_and_ports = {
+# cidrs = ["<ENTER_IP_VALUE>/32", "<ENTER_IP_VALUE>/32"],
+# ports = [443, 22]
+# }
 
 # ------- Optional inputs for BYO-VPC -------
 # **NOTE: Uncomment below settings if required

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -28,6 +28,7 @@ variable "aws_key_pair" {
 
   description = "Name of the Public SSH key for the CDP environment"
 
+  default = null
 }
 
 # ------- CDP Environment Deployment -------
@@ -44,6 +45,8 @@ variable "ingress_extra_cidrs_and_ports" {
     ports = list(number)
   })
   description = "List of extra CIDR blocks and ports to include in Security Group Ingress rules"
+
+  default = null
 }
 
 # ------- Optional inputs for BYO-VPC -------

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -89,14 +89,14 @@ locals {
   # key pair value
   public_key_text = (
     local.create_keypair == false ?
-    var.public_key_text : 
+    var.public_key_text :
     tls_private_key.cdp_private_key[0].public_key_openssh
   )
 }
 
 # Create and save a RSA key
 resource "tls_private_key" "cdp_private_key" {
-  count = local.create_keypair ? 1 : 0
+  count     = local.create_keypair ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 4096
 }
@@ -117,18 +117,18 @@ locals {
   lookup_ip = var.ingress_extra_cidrs_and_ports == null ? true : false
 
   # ingress value
-  ingress_extra_cidrs_and_ports = ( 
-    local.lookup_ip == false ? 
-      var.ingress_extra_cidrs_and_ports : 
-      { cidrs = ["${data.http.my_ip[0].response_body}/32"], 
-        ports = [443, 22]
-      }
-    )
+  ingress_extra_cidrs_and_ports = (
+    local.lookup_ip == false ?
+    var.ingress_extra_cidrs_and_ports :
+    { cidrs = ["${data.http.my_ip[0].response_body}/32"],
+      ports = [443, 22]
+    }
+  )
 }
 
 # Perform lookup of public IP of executing host
 data "http" "my_ip" {
   count = local.lookup_ip ? 1 : 0
-  
+
   url = "https://ifconfig.me/ip"
 }

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -31,7 +31,7 @@ module "cdp_azure_prereqs" {
   azure_region = var.azure_region
 
   deployment_template           = var.deployment_template
-  ingress_extra_cidrs_and_ports = var.ingress_extra_cidrs_and_ports
+  ingress_extra_cidrs_and_ports = local.ingress_extra_cidrs_and_ports
 
   # Inputs for BYO-VNet
   create_vnet            = var.create_vnet
@@ -48,7 +48,7 @@ module "cdp_deploy" {
   env_prefix          = var.env_prefix
   infra_type          = "azure"
   region              = var.azure_region
-  public_key_text     = var.public_key_text
+  public_key_text     = local.public_key_text
   deployment_template = var.deployment_template
 
   # From pre-reqs module output
@@ -79,4 +79,56 @@ module "cdp_deploy" {
   depends_on = [
     module.cdp_azure_prereqs
   ]
+}
+
+# ------- Create SSH Keypair if input public_key_text variable is not specified
+locals {
+  # flag to determine if keypair should be created
+  create_keypair = var.public_key_text == null ? true : false
+
+  # key pair value
+  public_key_text = (
+    local.create_keypair == false ?
+    var.public_key_text : 
+    tls_private_key.cdp_private_key[0].public_key_openssh
+  )
+}
+
+# Create and save a RSA key
+resource "tls_private_key" "cdp_private_key" {
+  count = local.create_keypair ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+# Save the private key to ./<env_prefix>-ssh-key.pem
+resource "local_sensitive_file" "pem_file" {
+  count = local.create_keypair ? 1 : 0
+
+  filename             = "${var.env_prefix}-ssh-key.pem"
+  file_permission      = "600"
+  directory_permission = "700"
+  content              = tls_private_key.cdp_private_key[0].private_key_pem
+}
+
+# ------- Lookup public ip for ingress settings if ingress_extra_cidrs_and_ports variable is not specified
+locals {
+  # flag to determine if public ip lookup should be performed for ingress
+  lookup_ip = var.ingress_extra_cidrs_and_ports == null ? true : false
+
+  # ingress value
+  ingress_extra_cidrs_and_ports = ( 
+    local.lookup_ip == false ? 
+      var.ingress_extra_cidrs_and_ports : 
+      { cidrs = ["${data.http.my_ip[0].response_body}/32"], 
+        ports = [443, 22]
+      }
+    )
+}
+
+# Perform lookup of public IP of executing host
+data "http" "my_ip" {
+  count = local.lookup_ip ? 1 : 0
+  
+  url = "https://ifconfig.me/ip"
 }

--- a/azure/terraform.tfvars.template
+++ b/azure/terraform.tfvars.template
@@ -18,17 +18,21 @@ env_prefix = "<ENTER_VALUE>" # Required name prefix for cloud and CDP resources,
 # ------- Cloud Settings -------
 azure_region = "<ENTER_VALUE>" # Change this to specify Cloud Provider region, e.g. eastus
 
-public_key_text = "<ENTER_VALUE>" # Change this with the SSH public key text, e.g. ssh-rsa AAA....
-
 # ------- CDP Environment Deployment -------
 deployment_template = "<ENTER_VALUE>"  # Specify the deployment pattern below. Options are public, semi-private or private
 
-# ------- Network Settings -------
-# **NOTE: If required change the values below any additional CIDRs to add the the AWS Security Groups**
-ingress_extra_cidrs_and_ports = {
- cidrs = ["<ENTER_IP_VALUE>/32", "<ENTER_IP_VALUE>/32"],
- ports = [443, 22]
-}
+
+
+# ------- Optional inputs for SSH key and Network Access Settings -------
+# **NOTE: Uncomment below settings if required
+
+# public_key_text = "<ENTER_VALUE>" # Set this to specifiy an existing SSH public key text, e.g. ssh-rsa AAA....
+
+# If required use the variable below for any additional CIDRs to add the Azure Security Groups
+# ingress_extra_cidrs_and_ports = {
+# cidrs = ["<ENTER_IP_VALUE>/32", "<ENTER_IP_VALUE>/32"],
+# ports = [443, 22]
+# }
 
 # ------- Optional inputs for BYO-VNet -------
 # **NOTE: Uncomment below settings if required

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -27,6 +27,8 @@ variable "public_key_text" {
   type = string
 
   description = "SSH Public key string for the nodes of the CDP environment"
+
+  default = null
 }
 
 # ------- CDP Environment Deployment -------
@@ -43,6 +45,8 @@ variable "ingress_extra_cidrs_and_ports" {
     ports = list(number)
   })
   description = "List of extra CIDR blocks and ports to include in Security Group Ingress rules"
+
+  default = null
 }
 
 # ------- Optional inputs for BYO-VNet -------

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -76,14 +76,14 @@ locals {
   # key pair value
   public_key_text = (
     local.create_keypair == false ?
-    var.public_key_text : 
+    var.public_key_text :
     tls_private_key.cdp_private_key[0].public_key_openssh
   )
 }
 
 # Create and save a RSA key
 resource "tls_private_key" "cdp_private_key" {
-  count = local.create_keypair ? 1 : 0
+  count     = local.create_keypair ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 4096
 }
@@ -104,18 +104,18 @@ locals {
   lookup_ip = var.ingress_extra_cidrs_and_ports == null ? true : false
 
   # ingress value
-  ingress_extra_cidrs_and_ports = ( 
-    local.lookup_ip == false ? 
-      var.ingress_extra_cidrs_and_ports : 
-      { cidrs = ["${data.http.my_ip[0].response_body}/32"], 
-        ports = [443, 22]
-      }
-    )
+  ingress_extra_cidrs_and_ports = (
+    local.lookup_ip == false ?
+    var.ingress_extra_cidrs_and_ports :
+    { cidrs = ["${data.http.my_ip[0].response_body}/32"],
+      ports = [443, 22]
+    }
+  )
 }
 
 # Perform lookup of public IP of executing host
 data "http" "my_ip" {
   count = local.lookup_ip ? 1 : 0
-  
+
   url = "https://ifconfig.me/ip"
 }

--- a/gcp/terraform.tfvars.template
+++ b/gcp/terraform.tfvars.template
@@ -20,17 +20,22 @@ gcp_project = "<ENTER_VALUE>" # Change this to specify the GCP Project ID
 
 gcp_region = "<ENTER_VALUE>" # Change this to specify Cloud Provider region, e.g. europe-west2
 
-public_key_text = "<ENTER_VALUE>" # Change this with the SSH public key text, e.g. ssh-rsa AAA....
 
 # ------- CDP Environment Deployment -------
 deployment_template = "<ENTER_VALUE>"  # Specify the deployment pattern below. Options are public, semi-private or private
 
-# ------- Network Settings -------
-# **NOTE: If required change the values below any additional CIDRs to add the the AWS Security Groups**
-ingress_extra_cidrs_and_ports = {
- cidrs = ["<ENTER_IP_VALUE>/32", "<ENTER_IP_VALUE>/32"],
- ports = [443, 22]
-}
+
+
+# ------- Optional inputs for SSH key and Network Access Settings -------
+# **NOTE: Uncomment below settings if required
+
+# public_key_text = "<ENTER_VALUE>" # Set this to specifiy an existing SSH public key text, e.g. ssh-rsa AAA....
+
+# If required use the variable below for any additional CIDRs to add the GCP Security Groups
+# ingress_extra_cidrs_and_ports = {
+# cidrs = ["<ENTER_IP_VALUE>/32", "<ENTER_IP_VALUE>/32"],
+# ports = [443, 22]
+# }
 
 # ------- Optional inputs for BYO-VPC -------
 # **NOTE: Uncomment below settings if required

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -32,6 +32,8 @@ variable "public_key_text" {
   type = string
 
   description = "SSH Public key string for the nodes of the CDP environment"
+
+  default = null
 }
 
 # ------- CDP Environment Deployment -------
@@ -48,6 +50,8 @@ variable "ingress_extra_cidrs_and_ports" {
     ports = list(number)
   })
   description = "List of extra CIDR blocks and ports to include in Security Group Ingress rules"
+
+  default = null
 }
 
 # ------- Optional inputs for BYO-VPC -------


### PR DESCRIPTION
Code changes to make the SSH key and extra ingress CIDRs optional inputs. 
If not specified:
* the SSH key is created using the `tls_private_key` Terraform resource;
* the public IP of the executing host is found by doing a http lookup of `https://ifconfig.me/ip`

To do:
- [x] Add ssh key generation and public ip lookup to AWS quickstart
- [x] Add ssh key generation and public ip lookup to Azure quickstart
- [x] Add ssh key generation and public ip lookup to GCP quickstart
- [x] Update docs and sample variable file to identify optional variable
