### PR TITLE
Update quickstart.sh scripts for async execution

### DIFF
--- a/aws/quickstart.sh
+++ b/aws/quickstart.sh
@@ -17,6 +17,10 @@
 export TF_VAR_aws_region="${1:-""}"
 export TF_VAR_env_prefix="${2:-""}"
 export TF_VAR_deployment_template="${3:-"semi-private"}"
+export TF_VAR_env_tags='{"deploy_tool": "express-tf", "env_prefix": "'"$2"'"}'
+export TF_VAR_create_vpc_endpoints="false"
+export TF_VAR_environment_async_creation="true"
+export TF_VAR_datalake_async_creation="true"
 
 # Install Terraform
 curl -fsSL https://releases.hashicorp.com/terraform/1.7.1/terraform_1.7.1_linux_amd64.zip -o terraform.zip
@@ -24,7 +28,7 @@ unzip -o terraform.zip -d ${HOME}
 rm terraform.zip
 
 # Checkout CDP Quickstart Repository
-git clone --branch v0.5.0 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
+git clone --branch v0.6.1 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
 cd cdp-tf-quickstarts/aws
 
 # Install CDP CLI and Log In

--- a/azure/quickstart.sh
+++ b/azure/quickstart.sh
@@ -17,9 +17,12 @@
 export TF_VAR_azure_region"=${1:-""}"
 export TF_VAR_env_prefix="${2:-""}"
 export TF_VAR_deployment_template="${4:-"semi-private"}"
+export TF_VAR_env_tags='{"deploy_tool": "express-tf", "env_prefix": "'"$2"'"}'
+export TF_VAR_environment_async_creation="true"
+export TF_VAR_datalake_async_creation="true"
 
 # Checkout CDP Quickstart Repository
-git clone --branch v0.5.0 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
+git clone --branch v0.6.1 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
 cd cdp-tf-quickstarts/azure
 
 # Install CDP CLI and Log In

--- a/gcp/quickstart.sh
+++ b/gcp/quickstart.sh
@@ -18,9 +18,12 @@ export TF_VAR_gcp_project="${1:-""}"
 export TF_VAR_gcp_region="${2:-""}"
 export TF_VAR_env_prefix="${3:-""}"
 export TF_VAR_deployment_template="${4:-"semi-private"}"
+export TF_VAR_env_tags='{"deploy_tool": "express-tf", "env_prefix": "'"$2"'"}'
+export TF_VAR_environment_async_creation="true"
+export TF_VAR_datalake_async_creation="true"
 
 # Checkout CDP Quickstart Repository
-git clone --branch v0.5.0 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
+git clone --branch v0.6.1 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
 cd cdp-tf-quickstarts/gcp
 
 # Install CDP CLI and Log In


### PR DESCRIPTION
Hi @balazsgaspar and @daszabo,

I've updated the express on-boarding scripts to point to the latest quickstart release. 
This allows us to enable asynchronous execution of the CDP resources.

I have added TF_VAR inputs for `env_tags` and, for AWS, to disable the creation of vpc endpoints.

Let me know if you spot any issues with the PR.