### PR TITLE
Add enable_raz input variable to quickstarts

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -98,6 +98,7 @@ module "cdp_deploy" {
   keypair_name        = local.aws_key_pair
   deployment_template = var.deployment_template
   datalake_scale      = var.datalake_scale
+  enable_raz          = var.enable_raz
   datalake_recipes    = var.datalake_recipes
   freeipa_recipes     = var.freeipa_recipes
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -104,6 +104,13 @@ variable "datalake_recipes" {
   default = null
 }
 
+variable "enable_raz" {
+  type = bool
+
+  description = "Flag to enable Ranger Authorization Service (RAZ)"
+
+  default = true
+}
 # ------- Network Resources -------
 variable "ingress_extra_cidrs_and_ports" {
   type = object({

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -84,6 +84,7 @@ module "cdp_deploy" {
   public_key_text     = local.public_key_text
   deployment_template = var.deployment_template
   datalake_scale      = var.datalake_scale
+  enable_raz          = var.enable_raz
   datalake_recipes    = var.datalake_recipes
   freeipa_recipes     = var.freeipa_recipes
   multiaz             = var.multiaz

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -105,6 +105,14 @@ variable "datalake_recipes" {
   default = null
 }
 
+variable "enable_raz" {
+  type = bool
+
+  description = "Flag to enable Ranger Authorization Service (RAZ)"
+
+  default = true
+}
+
 # ------- Network Resources -------
 variable "ingress_extra_cidrs_and_ports" {
   type = object({

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -71,6 +71,7 @@ module "cdp_deploy" {
   public_key_text     = local.public_key_text
   deployment_template = var.deployment_template
   datalake_scale      = var.datalake_scale
+  enable_raz          = var.enable_raz
   datalake_recipes    = var.datalake_recipes
   freeipa_recipes     = var.freeipa_recipes
 

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -101,6 +101,13 @@ variable "datalake_recipes" {
   default = null
 }
 
+variable "enable_raz" {
+  type = bool
+
+  description = "Flag to enable Ranger Authorization Service (RAZ)"
+
+  default = true
+}
 # ------- Network Resources -------
 variable "ingress_extra_cidrs_and_ports" {
   type = object({


### PR DESCRIPTION
Exposes the `enable_raz` input variable for the cdp_deploy module. Added to the AWS, Azure and GCP quickstarts. Default value is `true`.

Fixes #38.