### PR TITLE
Express onboarding fixes

### DIFF
--- a/aws/quickstart.sh
+++ b/aws/quickstart.sh
@@ -62,7 +62,7 @@ unzip -o terraform.zip -d ${HOME}
 rm terraform.zip
 
 # Checkout CDP Quickstart Repository
-git clone --branch v0.7.2 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
+git clone --branch v0.8.2 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
 cd cdp-tf-quickstarts/aws
 
 # Install CDP CLI and Log In

--- a/aws/quickstart.sh
+++ b/aws/quickstart.sh
@@ -19,7 +19,7 @@ export TF_VAR_env_prefix="${2:-""}"
 export ACCOUNT_ID="${3:-""}"
 export CDP_REGION="${4:-"us-west-1"}"
 export TF_VAR_deployment_template="${5:-"semi-private"}"
-export TF_VAR_ingress_extra_cidrs_and_ports="${6:-"{ cidrs = [\"0.0.0.0/0\"], ports = [443, 22] }"}"
+export TF_VAR_ingress_extra_cidrs_and_ports=${6:-"{ cidrs = [\"0.0.0.0/0\"], ports = [443, 22] }"}
 export TF_VAR_env_tags='{"deploy_tool": "express-tf", "env_prefix": "'"$2"'"}'
 export TF_VAR_create_vpc_endpoints="false"
 export TF_VAR_environment_async_creation="true"
@@ -34,11 +34,11 @@ export TF_VAR_aws_region="${TF_VAR_aws_region}"
 export TF_VAR_env_prefix="${TF_VAR_env_prefix}"
 export ACCOUNT_ID="${ACCOUNT_ID}"
 export TF_VAR_deployment_template="${TF_VAR_deployment_template}"
-export TF_VAR_env_tags="${TF_VAR_env_tags}"
+export TF_VAR_env_tags='${TF_VAR_env_tags}'
 export TF_VAR_create_vpc_endpoints="${TF_VAR_create_vpc_endpoints}"
 export TF_VAR_environment_async_creation="${TF_VAR_environment_async_creation}"
 export TF_VAR_datalake_async_creation="${TF_VAR_datalake_async_creation}"
-export TF_VAR_ingress_extra_cidrs_and_ports="${TF_VAR_ingress_extra_cidrs_and_ports}"
+export TF_VAR_ingress_extra_cidrs_and_ports='${TF_VAR_ingress_extra_cidrs_and_ports}'
 export TF_VAR_datalake_scale="${TF_VAR_datalake_scale}"
 EOF
 
@@ -47,9 +47,9 @@ destroy_file="destroy.sh"
 cat <<EOF > $destroy_file
 cd cdp-tf-quickstarts/aws
 
-source variables.sh
+source ${HOME}/variables.sh
 
-terraform destroy -auto-approve
+${HOME}/terraform destroy -auto-approve
 EOF
 
 # Make the file executable
@@ -69,8 +69,11 @@ cd cdp-tf-quickstarts/aws
 pip install cdpcli
 
 config_file="${HOME}/.cdp/config"
-region_config="cdp_region = ${CDP_REGION}"
-echo "$region_config" >> "$config_file"
+mkdir -p "$(dirname "$config_file")"
+cat <<EOF > $config_file
+[default]
+cdp_region = ${CDP_REGION}
+EOF
 
 cdp login --account-id "${ACCOUNT_ID}" --use-device-code
 

--- a/aws/quickstart.sh
+++ b/aws/quickstart.sh
@@ -24,6 +24,7 @@ export TF_VAR_env_tags='{"deploy_tool": "express-tf", "env_prefix": "'"$2"'"}'
 export TF_VAR_create_vpc_endpoints="false"
 export TF_VAR_environment_async_creation="true"
 export TF_VAR_datalake_async_creation="true"
+export TF_VAR_datalake_scale="LIGHT_DUTY"
 
 # Save TF variables to file
 output_file="variables.sh"
@@ -38,10 +39,22 @@ export TF_VAR_create_vpc_endpoints="${TF_VAR_create_vpc_endpoints}"
 export TF_VAR_environment_async_creation="${TF_VAR_environment_async_creation}"
 export TF_VAR_datalake_async_creation="${TF_VAR_datalake_async_creation}"
 export TF_VAR_ingress_extra_cidrs_and_ports="${TF_VAR_ingress_extra_cidrs_and_ports}"
+export TF_VAR_datalake_scale="${TF_VAR_datalake_scale}"
+EOF
+
+destroy_file="destroy.sh"
+
+cat <<EOF > $destroy_file
+cd cdp-tf-quickstarts/aws
+
+source variables.sh
+
+terraform destroy -auto-approve
 EOF
 
 # Make the file executable
 chmod +x $output_file
+chmod +x $destroy_file
 
 # Install Terraform
 curl -fsSL https://releases.hashicorp.com/terraform/1.7.1/terraform_1.7.1_linux_amd64.zip -o terraform.zip

--- a/aws/quickstart.sh
+++ b/aws/quickstart.sh
@@ -62,7 +62,7 @@ unzip -o terraform.zip -d ${HOME}
 rm terraform.zip
 
 # Checkout CDP Quickstart Repository
-git clone --branch v0.8.2 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
+git clone --branch v0.8.3 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
 cd cdp-tf-quickstarts/aws
 
 # Install CDP CLI and Log In

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -92,7 +92,7 @@ module "cdp_deploy" {
   datalake_async_creation    = var.datalake_async_creation
 
   # From pre-reqs module output
-  azure_subscription_id = module.cdp_azure_prereqs.azure_subscription_id
+  azure_subscription_id = var.azure_subscription_id == null ? module.cdp_azure_prereqs.azure_subscription_id : var.azure_subscription_id
   azure_tenant_id       = module.cdp_azure_prereqs.azure_tenant_id
 
   azure_resource_group_name      = module.cdp_azure_prereqs.azure_resource_group_name

--- a/azure/quickstart.sh
+++ b/azure/quickstart.sh
@@ -19,11 +19,12 @@ export TF_VAR_env_prefix="${2:-""}"
 export ACCOUNT_ID="${3:-""}"
 export CDP_REGION="${4:-"us-west-1"}"
 export TF_VAR_deployment_template="${5:-"semi-private"}"
-export TF_VAR_ingress_extra_cidrs_and_ports="${6:-"{ cidrs = [\"0.0.0.0/0\"], ports = [443, 22] }"}"
+export TF_VAR_ingress_extra_cidrs_and_ports=${6:-"{ cidrs = [\"0.0.0.0/0\"], ports = [443, 22] }"}
 export TF_VAR_env_tags='{"deploy_tool": "express-tf", "env_prefix": "'"$2"'"}'
 export TF_VAR_environment_async_creation="true"
 export TF_VAR_datalake_async_creation="true"
 export TF_VAR_datalake_scale="LIGHT_DUTY"
+export TF_VAR_azure_subscription_id="$(az account show --query id --output tsv)"
 
 # Save TF variables to file
 output_file="variables.sh"
@@ -33,11 +34,12 @@ export TF_VAR_azure_region="${TF_VAR_azure_region}"
 export TF_VAR_env_prefix="${TF_VAR_env_prefix}"
 export ACCOUNT_ID="${ACCOUNT_ID}"
 export TF_VAR_deployment_template="${TF_VAR_deployment_template}"
-export TF_VAR_env_tags="${TF_VAR_env_tags}"
+export TF_VAR_env_tags='${TF_VAR_env_tags}'
 export TF_VAR_environment_async_creation="${TF_VAR_environment_async_creation}"
 export TF_VAR_datalake_async_creation="${TF_VAR_datalake_async_creation}"
-export TF_VAR_ingress_extra_cidrs_and_ports="${TF_VAR_ingress_extra_cidrs_and_ports}"
+export TF_VAR_ingress_extra_cidrs_and_ports='${TF_VAR_ingress_extra_cidrs_and_ports}'
 export TF_VAR_datalake_scale="${TF_VAR_datalake_scale}"
+export TF_VAR_azure_subscription_id="${TF_VAR_azure_subscription_id}"
 EOF
 
 destroy_file="destroy.sh"
@@ -45,9 +47,9 @@ destroy_file="destroy.sh"
 cat <<EOF > $destroy_file
 cd cdp-tf-quickstarts/azure
 
-source variables.sh
+source ${HOME}/variables.sh
 
-terraform destroy -auto-approve
+${HOME}/terraform destroy -auto-approve
 EOF
 
 # Make the file executable
@@ -55,15 +57,18 @@ chmod +x $output_file
 chmod +x $destroy_file
 
 # Checkout CDP Quickstart Repository
-git clone --branch v0.7.2 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
+git clone --branch v0.8.2 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
 cd cdp-tf-quickstarts/azure
 
 # Install CDP CLI and Log In
 pip install cdpcli
 
 config_file="${HOME}/.cdp/config"
-region_config="cdp_region = ${CDP_REGION}"
-echo "$region_config" >> "$config_file"
+mkdir -p "$(dirname "$config_file")"
+cat <<EOF > $config_file
+[default]
+cdp_region = ${CDP_REGION}
+EOF
 
 cdp login --account-id "${ACCOUNT_ID}" --use-device-code
 

--- a/azure/quickstart.sh
+++ b/azure/quickstart.sh
@@ -57,7 +57,7 @@ chmod +x $output_file
 chmod +x $destroy_file
 
 # Checkout CDP Quickstart Repository
-git clone --branch v0.8.2 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
+git clone --branch v0.8.3 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
 cd cdp-tf-quickstarts/azure
 
 # Install CDP CLI and Log In

--- a/azure/quickstart.sh
+++ b/azure/quickstart.sh
@@ -23,6 +23,7 @@ export TF_VAR_ingress_extra_cidrs_and_ports="${6:-"{ cidrs = [\"0.0.0.0/0\"], po
 export TF_VAR_env_tags='{"deploy_tool": "express-tf", "env_prefix": "'"$2"'"}'
 export TF_VAR_environment_async_creation="true"
 export TF_VAR_datalake_async_creation="true"
+export TF_VAR_datalake_scale="LIGHT_DUTY"
 
 # Save TF variables to file
 output_file="variables.sh"
@@ -36,10 +37,22 @@ export TF_VAR_env_tags="${TF_VAR_env_tags}"
 export TF_VAR_environment_async_creation="${TF_VAR_environment_async_creation}"
 export TF_VAR_datalake_async_creation="${TF_VAR_datalake_async_creation}"
 export TF_VAR_ingress_extra_cidrs_and_ports="${TF_VAR_ingress_extra_cidrs_and_ports}"
+export TF_VAR_datalake_scale="${TF_VAR_datalake_scale}"
+EOF
+
+destroy_file="destroy.sh"
+
+cat <<EOF > $destroy_file
+cd cdp-tf-quickstarts/azure
+
+source variables.sh
+
+terraform destroy -auto-approve
 EOF
 
 # Make the file executable
 chmod +x $output_file
+chmod +x $destroy_file
 
 # Checkout CDP Quickstart Repository
 git clone --branch v0.7.2 https://github.com/cloudera-labs/cdp-tf-quickstarts.git

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -105,6 +105,14 @@ variable "datalake_recipes" {
   default = null
 }
 
+variable "azure_subscription_id" {
+  type = string
+
+  description = "The subscription where the environment should be deployed to"
+
+  default = null
+}
+
 # ------- Network Resources -------
 variable "ingress_extra_cidrs_and_ports" {
   type = object({

--- a/gcp/quickstart.sh
+++ b/gcp/quickstart.sh
@@ -57,7 +57,7 @@ chmod +x $output_file
 chmod +x $destroy_file
 
 # Checkout CDP Quickstart Repository
-git clone --branch v0.8.2 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
+git clone --branch v0.8.3 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
 cd cdp-tf-quickstarts/gcp
 
 # Install CDP CLI and Log In

--- a/gcp/quickstart.sh
+++ b/gcp/quickstart.sh
@@ -24,6 +24,7 @@ export TF_VAR_ingress_extra_cidrs_and_ports="${7:-"{ cidrs = [\"0.0.0.0/0\"], po
 export TF_VAR_env_tags='{"deploy_tool": "express-tf", "env_prefix": "'"$2"'"}'
 export TF_VAR_environment_async_creation="true"
 export TF_VAR_datalake_async_creation="true"
+export TF_VAR_datalake_scale="LIGHT_DUTY"
 
 # Save TF variables to file
 output_file="variables.sh"
@@ -38,10 +39,22 @@ export TF_VAR_env_tags="${TF_VAR_env_tags}"
 export TF_VAR_environment_async_creation="${TF_VAR_environment_async_creation}"
 export TF_VAR_datalake_async_creation="${TF_VAR_datalake_async_creation}"
 export TF_VAR_ingress_extra_cidrs_and_ports="${TF_VAR_ingress_extra_cidrs_and_ports}"
+export TF_VAR_datalake_scale="${TF_VAR_datalake_scale}"
+EOF
+
+destroy_file="destroy.sh"
+
+cat <<EOF > $destroy_file
+cd cdp-tf-quickstarts/gcp
+
+source variables.sh
+
+terraform destroy -auto-approve
 EOF
 
 # Make the file executable
 chmod +x $output_file
+chmod +x $destroy_file
 
 # Checkout CDP Quickstart Repository
 git clone --branch v0.7.2 https://github.com/cloudera-labs/cdp-tf-quickstarts.git

--- a/gcp/quickstart.sh
+++ b/gcp/quickstart.sh
@@ -20,7 +20,7 @@ export TF_VAR_env_prefix="${3:-""}"
 export ACCOUNT_ID="${4:-""}"
 export CDP_REGION="${5:-"us-west-1"}"
 export TF_VAR_deployment_template="${6:-"semi-private"}"
-export TF_VAR_ingress_extra_cidrs_and_ports="${7:-"{ cidrs = [\"0.0.0.0/0\"], ports = [443, 22] }"}"
+export TF_VAR_ingress_extra_cidrs_and_ports=${6:-"{ cidrs = [\"0.0.0.0/0\"], ports = [443, 22] }"}
 export TF_VAR_env_tags='{"deploy_tool": "express-tf", "env_prefix": "'"$2"'"}'
 export TF_VAR_environment_async_creation="true"
 export TF_VAR_datalake_async_creation="true"
@@ -32,13 +32,13 @@ output_file="variables.sh"
 cat <<EOF > $output_file
 export TF_VAR_gcp_project="${TF_VAR_gcp_project}"
 export TF_VAR_gcp_region="${TF_VAR_gcp_region}"
-export TF_VAR_env_prefix="${TF_VAR_env_prefix}"
+export TF_VAR_env_prefix='${TF_VAR_env_prefix}'
 export ACCOUNT_ID="${ACCOUNT_ID}"
 export TF_VAR_deployment_template="${TF_VAR_deployment_template}"
 export TF_VAR_env_tags="${TF_VAR_env_tags}"
 export TF_VAR_environment_async_creation="${TF_VAR_environment_async_creation}"
 export TF_VAR_datalake_async_creation="${TF_VAR_datalake_async_creation}"
-export TF_VAR_ingress_extra_cidrs_and_ports="${TF_VAR_ingress_extra_cidrs_and_ports}"
+export TF_VAR_ingress_extra_cidrs_and_ports='${TF_VAR_ingress_extra_cidrs_and_ports}'
 export TF_VAR_datalake_scale="${TF_VAR_datalake_scale}"
 EOF
 
@@ -47,9 +47,9 @@ destroy_file="destroy.sh"
 cat <<EOF > $destroy_file
 cd cdp-tf-quickstarts/gcp
 
-source variables.sh
+source ${HOME}/variables.sh
 
-terraform destroy -auto-approve
+${HOME}/terraform destroy -auto-approve
 EOF
 
 # Make the file executable
@@ -57,15 +57,18 @@ chmod +x $output_file
 chmod +x $destroy_file
 
 # Checkout CDP Quickstart Repository
-git clone --branch v0.7.2 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
+git clone --branch v0.8.2 https://github.com/cloudera-labs/cdp-tf-quickstarts.git
 cd cdp-tf-quickstarts/gcp
 
 # Install CDP CLI and Log In
 pip install cdpcli
 
 config_file="${HOME}/.cdp/config"
-region_config="cdp_region = ${CDP_REGION}"
-echo "$region_config" >> "$config_file"
+mkdir -p "$(dirname "$config_file")"
+cat <<EOF > $config_file
+[default]
+cdp_region = ${CDP_REGION}
+EOF
 
 cdp login --account-id "${ACCOUNT_ID}" --use-device-code
 


### PR DESCRIPTION
CB-27430 Change the data lake created by Express Onboarding to light duty
CB-27431 Move AWS Express Onboarding to CDP quickstart branch 0.8.2
CB-27432 azurerm requires subscription ID to be provided explicitly